### PR TITLE
Updated foundation-datepicker.js to allow both prefix and postfix comps.

### DIFF
--- a/example/js/foundation-datepicker.js
+++ b/example/js/foundation-datepicker.js
@@ -47,7 +47,7 @@
 		this.format = DPGlobal.parseFormat(options.format||this.element.data('date-format')||dates[this.language].format||'mm/dd/yyyy');
 		this.isInline = false;
 		this.isInput = this.element.is('input');
-		this.component = this.element.is('.date') ? this.element.find('.prefix') : false;
+		this.component = this.element.is('.date') ? this.element.find('.prefix, .postfix') : false;
 		this.hasInput = this.component && this.element.find('input').length;
 		
 		


### PR DESCRIPTION
With Foundation 4, we can now use the following components:

``` haml
.row.collapse.date
    %input.large-6.columns{...}
    %span.large-3.columns.postfix.end
```

This is a simple fix to allow the datepicker to be compatible with postfix.
