### PR TITLE
Added 'fi-x' class to close button to support foundation icons

### DIFF
--- a/example/js/foundation-datepicker.js
+++ b/example/js/foundation-datepicker.js
@@ -1057,7 +1057,7 @@
 									DPGlobal.footTemplate+
 								'</table>'+
 							'</div>'+
-							'<a class="button datepicker-close small alert right" style="width:auto;"><i class="fa fa-remove fa-times"></i></a>'+
+							'<a class="button datepicker-close small alert right" style="width:auto;"><i class="fa fa-remove fa-times fi-x"></i></a>'+
 						'</div>';
 
 	$.fn.fdatepicker.DPGlobal = DPGlobal;


### PR DESCRIPTION
I'm using https://github.com/zaiste/foundation-icons-sass-rails for icons (which uses http://zurb.com/playground/foundation-icon-fonts-3).  The arrows/chevrons were fixed already, but this adds an "x" icon to the close button.  Should have no impact on font awesome users.
