### PR TITLE
Fixed Font Awesome icons for left/right

### DIFF
--- a/example/js/foundation-datepicker.js
+++ b/example/js/foundation-datepicker.js
@@ -1026,9 +1026,9 @@
 		},
 		headTemplate: '<thead>'+
 							'<tr>'+
-								'<th class="prev"><i class="fi-arrow-left"/></th>'+
+								'<th class="prev"><i class="fa fa-chevron-left fi-arrow-left"/></th>'+
 								'<th colspan="5" class="date-switch"></th>'+
-								'<th class="next"><i class="fi-arrow-right"/></th>'+
+								'<th class="next"><i class="fa fa-chevron-right fi-arrow-right"/></th>'+
 							'</tr>'+
 						'</thead>',
 		contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',


### PR DESCRIPTION
I tried Font Awesome and noticed the arrows don't work.  I added `fa fa-cheveron-...` classes.
