### PR TITLE
Remove reliance on Font Awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,6 @@ http://foundation-datepicker.peterbeno.com/example.html
 2. copy the files
     3. **/js/foundation-datepicker.js**
     4. **/stylesheets/foundation-datepicker.css**
-       somewhere into your project 
+       somewhere into your project
 
-3. &lt;link&gt; and &lt;script&gt; them into your page 
-
-4. to see the arrows and icons, please include **font-awesome**:
-
-    &lt;link href=&quot;http://netdna.bootstrapcdn.com/font-awesome/3.0.2/css/font-awesome.css&quot; rel=&quot;stylesheet&quot;&gt;
-	
-
+3. &lt;link&gt; and &lt;script&gt; them into your page

--- a/example.html
+++ b/example.html
@@ -7,7 +7,6 @@
 		<meta name="author" content="Peter Beno, najlepsiwebdesigner@gmail.com">
 		<!-- CDN -->
 		<script src="http://code.jquery.com/jquery.min.js"></script>
-		<link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 		<script src="http://cdnjs.cloudflare.com/ajax/libs/prettify/r224/prettify.js"></script>
 		<link href="http://cdnjs.cloudflare.com/ajax/libs/prettify/r224/prettify.css" rel="stylesheet">
 		<link href='http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,300,600,700&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
@@ -69,7 +68,7 @@
 						<li>separators: -, /, .</li>
 					</ul>
 					<div class="alert-box">
-						<h6>Warning!</h6> 
+						<h6>Warning!</h6>
 						<br>This plugin uses really robust, tested base bootstrap-datepicker plugin, projects are now not in sync. This datepicker is based on old version of bootstrap-datepicker, but it works well. If you find an error, please report it to github. Thanks! :)</div>
 					<p>
 						<a href="https://twitter.com/share" class="twitter-share-button" data-via="benopeter">Tweet</a>

--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -82,8 +82,6 @@
 		}
 		if (this.isRTL){
 			this.picker.addClass('datepicker-rtl');
-			this.picker.find('.prev i, .next i')
-						.toggleClass('fa fa-chevron-left fa-chevron-right').toggleClass('fa-chevron-left fa-chevron-right');
 		}
 		$(document).on('mousedown', function (e) {
 			// Clicked outside the datepicker, hide it
@@ -1058,9 +1056,9 @@
 		},
 		headTemplate: '<thead>'+
 							'<tr>'+
-								'<th class="prev"><i class="fa fa-chevron-left fi-arrow-left"/></th>'+
+								'<th class="prev">&lt;</th>'+
 								'<th colspan="5" class="date-switch"></th>'+
-								'<th class="next"><i class="fa fa-chevron-right fi-arrow-right"/></th>'+
+								'<th class="next">&gt;</th>'+
 							'</tr>'+
 						'</thead>',
 		contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',
@@ -1089,7 +1087,7 @@
 									DPGlobal.footTemplate+
 								'</table>'+
 							'</div>'+
-							'<a class="button datepicker-close small alert right" style="width:auto;"><i class="fa fa-remove fa-times fi-x"></i></a>'+
+							'<a class="button datepicker-close small alert right" style="width:auto;">&times;</a>'+
 						'</div>';
 
 	$.fn.fdatepicker.DPGlobal = DPGlobal;


### PR DESCRIPTION
No need to load an entire web font for 3 icons, reverting to basic characters, so foundation-datepicker can be dropped in as a standalone widget, no unnecessary dependencies.
