### PR TITLE
closeButton option is dependent on the order of css inclusion

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -74,6 +74,8 @@
 							});
 		if (this.closeButton){
 			this.picker.find('a.datepicker-close').show();
+		} else {
+			this.picker.find('a.datepicker-close').hide();
 		}
 
 		if(this.isInline) {


### PR DESCRIPTION
Currently the order css files (foundation and foundation-datepicker) can cause closeButton option to stop working because if foundation-datepicker is loaded before the foundation, then the option won't work. To let the solution work even in that case, we can add a javascript line to hide the close button when the option is disabled.