### PR TITLE
TR (Turkish) language support added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Available languages are:
 - Greek (el)
 - Ukrainian (uk)
 - Norwegian (no)
+- Turkish (tr)
 	
 Version without Font Awesome
 -------------------

--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -810,6 +810,14 @@
 			monthsShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
 			today: "Today"
 		},
+		tr: {
+			days: ["Pazar", "Pazartesi", "Salı", "Çarşamba", "Perşembe", "Cuma", "Cumartesi", "Pazar"],
+			daysShort: ["Pzr", "Pzt", "Sal", "Çarş", "Perş", "Cum", "Cmt", "Pzr"],
+			daysMin: ["Pz", "Pt", "Sa", "Ça", "Pe", "Cu", "Ct", "Pz"],
+			months: ["Ocak", "Şubat", "Mart", "Nisan", "Mayıs", "Haziran", "Temmuz", "Ağustos", "Eylül", "Ekim", "Kasım", "Aralık"],
+			monthsShort: ["Oca", "Şub", "Mar", "Nis", "May", "Haz", "Tem", "Ağu", "Eyl", "Eki", "Kas", "Ara"],
+			today: "Bugün"
+		},
 		fr: {
 			days: ["Dimanche", "Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"],
 			daysShort: ["Dim", "Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"],


### PR DESCRIPTION
I've just added Turkish language support.

For example:
```javascript
$('#event_date').fdatepicker({
  format: 'dd/mm/yyyy',
  weekStart: '1',
  language: 'tr'
});
```