### PR TITLE
Corrected the path to the CSS file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Peter Beňo <najlepsiwebdesigner@gmail.com>"
   ],
   "description": "Foundation datepicker jQuery plugin",
-  "main": ["js/foundation-datepicker.js","stylesheets/foundation-datepicker.css"],
+  "main": ["js/foundation-datepicker.js","css/foundation-datepicker.css"],
   "keywords": [
     "foundation",
     "datepicker",


### PR DESCRIPTION
The `main` property in `bower.json` is used by some NPM packages to inject the required assets to the HTML automatically. The reference to the stylesheet wasn't correct, I had to override it on my global `bower.json` to inject it correctly.