### PR TITLE
Remove stray character breaking scripts.

### DIFF
--- a/js/locales/foundation-datepicker.lv.js
+++ b/js/locales/foundation-datepicker.lv.js
@@ -1,4 +1,4 @@
-w/**
+/**
  * Latvian translation for foundation-datepicker
  * Artis Avotins <artis@apit.lv>
  */

--- a/js/locales/foundation-datepicker.vi.js
+++ b/js/locales/foundation-datepicker.vi.js
@@ -7,7 +7,6 @@
 		days: ["Chủ Nhật","Thứ 2", "Thứ 3", "Thứ 4", "Thứ 5", "Thứ 6", "Thứ 7", "Chủ Nhật"],
 		daysShort: ["CN", "T2", "T3", "T4", "T5", "T6", "T7", "CN"],
 		daysMin: ["CN", "T2", "T3", "T4", "T5", "T6", "T7", "CN"],
-		daysMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"],
 		months: ["Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"],
 		monthsShort: ["Thg1", "Thg2", "Thg3", "Thg4", "Thg5", "Thg6", "Thg7", "Thg8", "Thg9", "Thg10", "Thg11", "Thg12"],
 		today: "Hôm nay"


### PR DESCRIPTION
Removing stray 'w' from beginning of file causing js scripts to break due to w never being defined.