### PR TITLE
change on the fly onRender function

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -1058,9 +1058,11 @@
             var $this = $(this),
                 data = $this.data('datepicker'),
                 options = typeof option == 'object' && option;
-            if (!data) {
+            if (!data)
                 $this.data('datepicker', (data = new Datepicker(this, $.extend({}, $.fn.fdatepicker.defaults, options))));
-            }
+            else
+                if(options.onRender && typeof options.onRender == 'function')
+                    $this.data().datepicker.onRender = options.onRender;
             if (typeof option == 'string' && typeof data[option] == 'function') {
                 data[option].apply(data, args);
             }


### PR DESCRIPTION
Allow to change the onRender callback function AFTER the datepicker have been initialized.

Could be applied to all other options, I needed only this one, tell me if you find it useful and I will do the others
