### PR TITLE
Ability to use different CSS prefix for Font Awesome icons. By defaul…

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -40,6 +40,7 @@
         this.minuteStep = options.minuteStep || this.element.data('minute-step') || 5;
         this.pickerPosition = options.pickerPosition || this.element.data('picker-position') || 'bottom-right';
         this.initialDate = options.initialDate || null;
+        this.faCSSprefix = options.faCSSprefix || 'fa';
 
         this._attachEvents();
 
@@ -111,7 +112,7 @@
         if (this.isRTL) {
             this.picker.addClass('datepicker-rtl');
             this.picker.find('.prev i, .next i')
-                .toggleClass('fa-chevron-left fa-chevron-right');
+                .toggleClass(this.faCSSprefix + '-chevron-left ' + this.faCSSprefix + '-chevron-right');
         }
         $(document).on('mousedown', function(e) {
             // Clicked outside the datepicker, hide it
@@ -1306,9 +1307,9 @@
         },
         headTemplate: '<thead>' +
             '<tr>' +
-            '<th class="prev"><i class="fa fa-chevron-left fi-arrow-left"/></th>' +
+            '<th class="prev"><i class="' + this.faCSSprefix + ' ' + this.faCSSprefix + '-chevron-left fi-arrow-left"/></th>' +
             '<th colspan="5" class="date-switch"></th>' +
-            '<th class="next"><i class="fa fa-chevron-right fi-arrow-right"/></th>' +
+            '<th class="next"><i class="' + this.faCSSprefix + ' ' + this.faCSSprefix + '-chevron-right fi-arrow-right"/></th>' +
             '</tr>' +
             '</thead>',
         contTemplate: '<tbody><tr><td colspan="7"></td></tr></tbody>',
@@ -1350,7 +1351,7 @@
         DPGlobal.footTemplate +
         '</table>' +
         '</div>' +
-        '<a class="button datepicker-close tiny alert right" style="width:auto;"><i class="fa fa-remove fa-times fi-x"></i></a>' +
+        '<a class="button datepicker-close tiny alert right" style="width:auto;"><i class="' + this.faCSSprefix + ' ' + this.faCSSprefix + '-remove ' + this.faCSSprefix + '-times fi-x"></i></a>' +
         '</div>';
 
     $.fn.fdatepicker.DPGlobal = DPGlobal;


### PR DESCRIPTION
Sometimes there is a requirement to use Font Awesome with different CSS fa prefix. In order to do that foundation date picker may have an option to allow user to specify different CSS fa prefix for Font Awesome.