### PR TITLE
Add option to override the header template of Datepicker

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -40,6 +40,7 @@
         this.minuteStep = options.minuteStep || this.element.data('minute-step') || 5;
         this.pickerPosition = options.pickerPosition || this.element.data('picker-position') || 'bottom-right';
         this.initialDate = options.initialDate || null;
+        this.headTemplate = options.headTemplate || null;
 
         this._attachEvents();
 
@@ -90,6 +91,9 @@
             this.forceParse = this.element.data('date-force-parse');
         }
 
+        if(options.headTemplate !== null) {
+            DPGlobal.template = DPGlobal.template.replace(/<thead>(.*?)<\/thead>/g, "<thead>" + options.headTemplate +"</thead>");
+        }
 
         this.picker = $(DPGlobal.template)
             .appendTo(this.isInline ? this.element : this.appendTo)


### PR DESCRIPTION
Hey,
i added an option to override the "headTemplate".
```
$('.datepickThis').fdatepicker({
    initialDate: new Date(),
    format: 'dd-mm-yyyy hh:mm',
    pickTime: true,
    headTemplate: '<tr><th class="prev"><i class="icon fi-arrow-left"/></th><th colspan="5" class="date-switch"></th><th class="next"><i class="icon fi-arrow-right"/></th></tr>'
});
```

Cheers,
Jochen