### PR TITLE
Fix the bug that when the date is in the far future the picker crash with browser 

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -396,6 +396,10 @@
             }
             else {
                 date = this.isInput ? this.element.val() : this.element.data('date') || this.element.find('input').val();
+
+                if (date.length > 12) {
+                  date = "Future's future" // Fix the bug that when the date is in the far future the picker crash
+                }
             }
 
 


### PR DESCRIPTION
Fix the bug that when the date is in the far future the picker crash with browser 

User can input 1112222-05-05 as a date in the text field then the datepicker crash with browser.