### PR TITLE
If input is readonly click should show the picker.

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -200,7 +200,8 @@
                         [this.element, {
                             focus: (this.autoShow) ? $.proxy(this.show, this) : function() {},
                             keyup: $.proxy(this.update, this),
-                            keydown: $.proxy(this.keydown, this)
+                            keydown: $.proxy(this.keydown, this),
+                            click: (this.element.attr('readonly')) ? $.proxy(this.show, this) : function() {}
                         }]
                     ];
                 } 


### PR DESCRIPTION
On mobile devices readonly is useful to prevent keyboard from showing however if you selected and wanted to change the value by clicking on input, the picker would not show. This fixes it by showing the picker every time someone clicks on the input (if readonly).