### PR TITLE
Add 'main' section to 'package.json' for 'webpack'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "foundation-datepicker",
   "version": "1.5.5",
+  "main": "js/foundation-datepicker.min.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Webpack error: Module not found: Error: Cannot resolve module 'foundation-datepicker'.

The 'package.json' file does not have a 'main' property. When I added it by myself, webpack would start successfully.

{
...
"main": "js/foundation-datepicker.js",
...
}