### PR TITLE
Focus input field when datepicker is open should not close the datepicker

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -123,6 +123,10 @@
 
         }
         $(document).on('mousedown', function(e) {
+            if (that.isInput && e.target === that.element[0]) {
+                return;
+            }
+
             // Clicked outside the datepicker, hide it
             if ($(e.target).closest('.datepicker.datepicker-inline, .datepicker.datepicker-dropdown').length === 0) {
                 that.hide();


### PR DESCRIPTION
If the datepicker is attached an input element the user can click the input field. This opens the datepicker.
If the datepicker is opened, the user can click the input field again but this closes the datepicker. This is counter intuitive. 
When the datepicker is closed, clicking in the input field again does not open the datepicker. This is very annoying.

The applied patch is a fix to solve the first issue, meaning, if the datepicker is attached to an input field, clicking the input field again does not close the datepicker. The second problem described above is therefor also fixed, since that state cannot be reached any more.
