### PR TITLE
Determine highest z-index

### DIFF
--- a/js/foundation-datepicker.js
+++ b/js/foundation-datepicker.js
@@ -386,9 +386,13 @@
 
         place: function() {
             if (this.isInline) return;
-            var zIndex = parseInt(this.element.parents().filter(function() {
-                return $(this).css('z-index') != 'auto';
-            }).first().css('z-index')) + 10;
+            var zIndexes = [];
+            this.element.parents().map(function() {
+                if ($(this).css('z-index') != 'auto') {
+                    zIndexes.push(parseInt($(this).css('z-index')));
+                }
+            });
+            var zIndex = zIndexes.sort(function(a, b) { return a - b; }).pop() + 10;
             var textbox = this.component ? this.component : this.element;
             var offset = textbox.offset();
             var height = textbox.outerHeight() + parseInt(textbox.css('margin-top'));


### PR DESCRIPTION
Origin logic to determine the _'z-index'_ to apply to the widget works only when elements are ordered by its _z-indexes_.

The datepicker did not show up when input element is in a [foundation reveal box](http://foundation.zurb.com/sites/docs/reveal.html).

Now z-indexes are extracted and sorted.