### PR TITLE
Update Catalan translation

### DIFF
--- a/js/locales/foundation-datepicker.ca.js
+++ b/js/locales/foundation-datepicker.ca.js
@@ -4,11 +4,11 @@
  */
 ;(function($){
 	$.fn.fdatepicker.dates['ca'] = {
-		days: ["Diumenge", "Dilluns", "Dimarts", "Dimecres", "Dijous", "Divendres", "Dissabte"],
-		daysShort: ["Diu",  "Dil", "Dmt", "Dmc", "Dij", "Div", "Dis"],
-		daysMin: ["dg", "dl", "dt", "dc", "dj", "dv", "ds"],
-		months: ["Gener", "Febrer", "Març", "Abril", "Maig", "Juny", "Juliol", "Agost", "Setembre", "Octubre", "Novembre", "Desembre"],
-		monthsShort: ["Gen", "Feb", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Oct", "Nov", "Des"],
+		days: ["diumenge", "dilluns", "dimarts", "dimecres", "dijous", "divendres", "dissabte"],
+		daysShort: ["dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds."],
+		daysMin: ["dg.", "dl.", "dt.", "dc.", "dj.", "dv.", "ds."],
+		months: ["gener", "febrer", "març", "abril", "maig", "juny", "juliol", "agost", "setembre", "octubre", "novembre", "desembre"],
+		monthsShort: ["gen.", "febr.", "març", "abr.", "maig", "juny", "jul.", "ag.", "set.", "oct.", "nov.", "des."],
 		today: "Avui",
 		clear: "Esborrar",
 		weekStart: 1,


### PR DESCRIPTION
Month and day names should be downcased, and abbreviations always wear a dot at the end. Also, some month names are not abbreviated.