### PR TITLE
Fix: Correction for Ponedjeljak (Monday) and Četvrtak (Thursday)

### DIFF
--- a/js/locales/foundation-datepicker.hr.js
+++ b/js/locales/foundation-datepicker.hr.js
@@ -3,7 +3,7 @@
  */
 ;(function($){
 	$.fn.fdatepicker.dates['hr'] = {
-		days: ["Nedjelja", "Ponedjelja", "Utorak", "Srijeda", "Četrtak", "Petak", "Subota", "Nedjelja"],
+		days: ["Nedjelja", "Ponedjeljak", "Utorak", "Srijeda", "Četvrtak", "Petak", "Subota", "Nedjelja"],
 		daysShort: ["Ned", "Pon", "Uto", "Srr", "Čet", "Pet", "Sub", "Ned"],
 		daysMin: ["Ne", "Po", "Ut", "Sr", "Če", "Pe", "Su", "Ne"],
 		months: ["Siječanj", "Veljača", "Ožujak", "Travanj", "Svibanj", "Lipanj", "Srpanj", "Kolovoz", "Rujan", "Listopad", "Studeni", "Prosinac"],

--- a/js/locales/foundation-datepicker.lb-LU.js
+++ b/js/locales/foundation-datepicker.lb-LU.js
@@ -1,0 +1,13 @@
+/**
+ * Luxembourgish localisation
+ */
+;(function($){
+	$.fn.fdatepicker.dates['lb-LU'] = {
+		days: ["Sonndeg", "Méindeg", "Dënschdeg", "Mëttwoch", "Donneschdeg", "Freideg", "Samschdeg", "Sonndeg"],
+		daysShort: ["Son", "Méi", "Dën", "Mët", "Don", "Fre", "Sam", "Son"],
+		daysMin: ["So", "Mé", "Dë", "Më", "Do", "Fr", "Sa", "So"],
+		months: ["Januar", "Februar", "Mäerz", "Abrëll", "Mee", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember"], 
+		monthsShort: ["Jan", "Febr", "Mrz", "Abr", "Mee", "Jun", "Jul", "Aug", "Sept", "Okt", "Nov", "Dez"],
+		today: "Haut"
+	};
+}(jQuery));


### PR DESCRIPTION
Corrected two small typos for Monday and Thursday

- https://hjp.znanje.hr/index.php?show=search_by_id&id=eVpnWBU%3D&keyword=ponedjeljak
- https://hjp.znanje.hr/index.php?show=search_by_id&id=f1pmXhA%3D&keyword=%C4%8Detvrtak